### PR TITLE
Allocator fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ string(TOLOWER "${CMAKE_BUILD_TOOL}" MY_BUILDTOOL)
 if(MY_BUILDTOOL MATCHES "(msdev|devenv|nmake|msbuild)")
     target_compile_options(testlib PUBLIC /W4 /WX)
 else()
-    target_compile_options(testlib PUBLIC -Wall -Weffc++ -Werror)
+    target_compile_options(testlib PUBLIC -Wall -Weffc++ -Werror -pedantic)
     # These are enabled on Clang and don't help...
     target_compile_options(testlib PUBLIC -Wno-missing-braces)
     target_link_libraries(testlib pthread)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,11 @@ string(TOLOWER "${CMAKE_BUILD_TOOL}" MY_BUILDTOOL)
 if(MY_BUILDTOOL MATCHES "(msdev|devenv|nmake|msbuild)")
     target_compile_options(testlib PUBLIC /W4 /WX)
 else()
-    target_compile_options(testlib PUBLIC -Wall -Weffc++ -Werror -pedantic)
+    target_compile_options(testlib PUBLIC -Wall -Weffc++ -Werror -Wextra -pedantic
+                                          -Wunused -Wredundant-decls  -Wunreachable-code
+                                          -Wold-style-cast -Wshadow
+                                          -Wconversion -Wsign-conversion  -Wno-conversion-null
+                                          -Wcast-align)
     # These are enabled on Clang and don't help...
     target_compile_options(testlib PUBLIC -Wno-missing-braces)
     target_link_libraries(testlib pthread)

--- a/include/spsl/hash.hpp
+++ b/include/spsl/hash.hpp
@@ -76,12 +76,12 @@ inline uint64_t rotl64(uint64_t x, int8_t r)
 // Block read - if your platform needs to do endian-swapping or can only
 // handle aligned reads, do the conversion here
 
-FORCE_INLINE uint32_t getblock32(const uint32_t* p, int i)
+FORCE_INLINE uint32_t getblock32(const uint32_t* p, uint32_t i)
 {
     return p[i];
 }
 
-FORCE_INLINE uint64_t getblock64(const uint64_t* p, int i)
+FORCE_INLINE uint64_t getblock64(const uint64_t* p, std::size_t i)
 {
     return p[i];
 }
@@ -115,10 +115,10 @@ FORCE_INLINE uint64_t fmix64(uint64_t k)
 
 //-----------------------------------------------------------------------------
 
-inline void MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* out)
+inline void MurmurHash3_x86_32(const void* key, const uint32_t len, uint32_t seed, void* out)
 {
-    const uint8_t* data = (const uint8_t*)key;
-    const int nblocks = len / 4;
+    const uint8_t* data = reinterpret_cast<const uint8_t*>(key);
+    const uint32_t nblocks = len / 4;
 
     uint32_t h1 = seed;
 
@@ -128,9 +128,9 @@ inline void MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* ou
     //----------
     // body
 
-    const uint32_t* blocks = (const uint32_t*)(data + nblocks * 4);
+    const uint32_t* blocks = reinterpret_cast<const uint32_t*>(data);
 
-    for (int i = -nblocks; i; i++)
+    for (uint32_t i = 0; i < nblocks; ++i)
     {
         uint32_t k1 = getblock32(blocks, i);
 
@@ -146,17 +146,17 @@ inline void MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* ou
     //----------
     // tail
 
-    const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
+    const uint8_t* tail = (data + nblocks * 4);
 
     uint32_t k1 = 0;
 
     switch (len & 3)
     {
     case 3:
-        k1 ^= tail[2] << 16;
+        k1 ^= static_cast<uint32_t>(tail[2] << 16);
     /* no break */
     case 2:
-        k1 ^= tail[1] << 8;
+        k1 ^= static_cast<uint32_t>(tail[1] << 8);
     /* no break */
     case 1:
         k1 ^= tail[0];
@@ -173,15 +173,16 @@ inline void MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* ou
 
     h1 = fmix32(h1);
 
-    *(uint32_t*)out = h1;
+    *static_cast<uint32_t*>(out) = h1;
 }
 
 //-----------------------------------------------------------------------------
 
-inline void MurmurHash3_x64_128(const void* key, const int len, const uint32_t seed, void* out)
+inline void MurmurHash3_x64_128(const void* key, const std::size_t len, const uint32_t seed,
+                                void* out)
 {
-    const uint8_t* data = (const uint8_t*)key;
-    const int nblocks = len / 16;
+    const uint8_t* data = reinterpret_cast<const uint8_t*>(key);
+    const std::size_t nblocks = len / 16;
 
     uint64_t h1 = seed;
     uint64_t h2 = seed;
@@ -192,9 +193,9 @@ inline void MurmurHash3_x64_128(const void* key, const int len, const uint32_t s
     //----------
     // body
 
-    const uint64_t* blocks = (const uint64_t*)(data);
+    const uint64_t* blocks = reinterpret_cast<const uint64_t*>(data);
 
-    for (int i = 0; i < nblocks; i++)
+    for (std::size_t i = 0; i < nblocks; i++)
     {
         uint64_t k1 = getblock64(blocks, i * 2 + 0);
         uint64_t k2 = getblock64(blocks, i * 2 + 1);
@@ -221,7 +222,7 @@ inline void MurmurHash3_x64_128(const void* key, const int len, const uint32_t s
     //----------
     // tail
 
-    const uint8_t* tail = (const uint8_t*)(data + nblocks * 16);
+    const uint8_t* tail = (data + nblocks * 16);
 
     uint64_t k1 = 0;
     uint64_t k2 = 0;
@@ -229,25 +230,25 @@ inline void MurmurHash3_x64_128(const void* key, const int len, const uint32_t s
     switch (len & 15)
     {
     case 15:
-        k2 ^= ((uint64_t)tail[14]) << 48;
+        k2 ^= (static_cast<uint64_t>(tail[14])) << 48;
     /* no break */
     case 14:
-        k2 ^= ((uint64_t)tail[13]) << 40;
+        k2 ^= (static_cast<uint64_t>(tail[13])) << 40;
     /* no break */
     case 13:
-        k2 ^= ((uint64_t)tail[12]) << 32;
+        k2 ^= (static_cast<uint64_t>(tail[12])) << 32;
     /* no break */
     case 12:
-        k2 ^= ((uint64_t)tail[11]) << 24;
+        k2 ^= (static_cast<uint64_t>(tail[11])) << 24;
     /* no break */
     case 11:
-        k2 ^= ((uint64_t)tail[10]) << 16;
+        k2 ^= (static_cast<uint64_t>(tail[10])) << 16;
     /* no break */
     case 10:
-        k2 ^= ((uint64_t)tail[9]) << 8;
+        k2 ^= (static_cast<uint64_t>(tail[9])) << 8;
     /* no break */
     case 9:
-        k2 ^= ((uint64_t)tail[8]) << 0;
+        k2 ^= (static_cast<uint64_t>(tail[8])) << 0;
         k2 *= c2;
         k2 = ROTL64(k2, 33);
         k2 *= c1;
@@ -255,28 +256,28 @@ inline void MurmurHash3_x64_128(const void* key, const int len, const uint32_t s
     /* no break */
 
     case 8:
-        k1 ^= ((uint64_t)tail[7]) << 56;
+        k1 ^= (static_cast<uint64_t>(tail[7])) << 56;
     /* no break */
     case 7:
-        k1 ^= ((uint64_t)tail[6]) << 48;
+        k1 ^= (static_cast<uint64_t>(tail[6])) << 48;
     /* no break */
     case 6:
-        k1 ^= ((uint64_t)tail[5]) << 40;
+        k1 ^= (static_cast<uint64_t>(tail[5])) << 40;
     /* no break */
     case 5:
-        k1 ^= ((uint64_t)tail[4]) << 32;
+        k1 ^= (static_cast<uint64_t>(tail[4])) << 32;
     /* no break */
     case 4:
-        k1 ^= ((uint64_t)tail[3]) << 24;
+        k1 ^= (static_cast<uint64_t>(tail[3])) << 24;
     /* no break */
     case 3:
-        k1 ^= ((uint64_t)tail[2]) << 16;
+        k1 ^= (static_cast<uint64_t>(tail[2])) << 16;
     /* no break */
     case 2:
-        k1 ^= ((uint64_t)tail[1]) << 8;
+        k1 ^= (static_cast<uint64_t>(tail[1])) << 8;
     /* no break */
     case 1:
-        k1 ^= ((uint64_t)tail[0]) << 0;
+        k1 ^= (static_cast<uint64_t>(tail[0])) << 0;
         k1 *= c1;
         k1 = ROTL64(k1, 31);
         k1 *= c2;
@@ -298,8 +299,8 @@ inline void MurmurHash3_x64_128(const void* key, const int len, const uint32_t s
     h1 += h2;
     h2 += h1;
 
-    ((uint64_t*)out)[0] = h1;
-    ((uint64_t*)out)[1] = h2;
+    static_cast<uint64_t*>(out)[0] = h1;
+    static_cast<uint64_t*>(out)[1] = h2;
 }
 
 //-----------------------------------------------------------------------------
@@ -320,7 +321,7 @@ template <>
 inline size_t hash_impl<32>(const void* buffer, size_t len)
 {
     uint32_t result = 0;
-    murmurhash3::MurmurHash3_x86_32(buffer, len, 0 /* seed */, &result);
+    murmurhash3::MurmurHash3_x86_32(buffer, static_cast<uint32_t>(len), 0 /* seed */, &result);
     return result;
 }
 
@@ -337,10 +338,9 @@ inline size_t hash_impl<64>(const void* buffer, size_t len)
     murmurhash3::MurmurHash3_x64_128(buffer, len, 0 /* seed */, result128);
 
     // this is the only "defined" way to convert properly...
-    // TODO: Why does MSVC complain about size_t != uint64_t?!
     size_t result = 0;
     memcpy(&result, result128, sizeof(result));
-	return result;
+    return result;
 }
 
 /**

--- a/include/spsl/policies.hpp
+++ b/include/spsl/policies.hpp
@@ -86,7 +86,7 @@ struct Throw
     {
         if (cap > max)
             throw std::length_error("requested capacity exceeds maximum");
-    };
+    }
     template <typename char_type, typename size_type>
     static size_type checkAssign(const char_type*, size_type n, size_type max)
     {

--- a/include/spsl/storage_array.hpp
+++ b/include/spsl/storage_array.hpp
@@ -133,7 +133,8 @@ public:
     }
     void push_back(char_type c)
     {
-        const size_type n = overflow_policy::checkAppend((size_type)1, c, size(), max_size());
+        const size_type n =
+          overflow_policy::checkAppend(static_cast<size_type>(1), c, size(), max_size());
         if (n)
         {
             m_buffer[m_length++] = c;

--- a/include/spsl/storage_password.hpp
+++ b/include/spsl/storage_password.hpp
@@ -33,7 +33,7 @@ inline void* secure_memzero(void* ptr, size_t size) noexcept
     // For more info, start here:
     // http://stackoverflow.com/questions/9973260/what-is-the-correct-way-to-clear-sensitive-data-from-memory-in-ios
 
-    volatile char* p = (char*)ptr;
+    volatile char* p = reinterpret_cast<char*>(ptr);
     while (size--)
         *p++ = 0;
     return ptr;
@@ -82,7 +82,7 @@ public:
     const allocator& getAllocator() const noexcept { return *this; }
 
     // note: This function is *not* constexpr to stay compatible with C++11
-    static const size_type _roundRequiredCapacityToBlockSize(size_type cap)
+    static size_type _roundRequiredCapacityToBlockSize(size_type cap)
     {
         size_type numBlocks = cap / BlockSize;
         if (numBlocks * BlockSize < cap)
@@ -430,14 +430,15 @@ protected:
 protected:
     // we store length + capacity information in a union that we also use as empty string
     // representation (assumption: m_buffer == _b => m_length == m_capacity == 0)
+    struct SizeInfo
+    {
+        /// number of bytes (*not* characters) in the buffer, not including the terminating NUL
+        size_type m_length;
+        /// number of bytes (*not* characters) allocated
+        size_type m_capacity;
+    };
     union {
-        struct
-        {
-            /// number of bytes (*not* characters) in the buffer, not including the terminating NUL
-            size_type m_length;
-            /// number of bytes (*not* characters) allocated
-            size_type m_capacity;
-        } _l;
+        SizeInfo _l;
         char_type _b[1];
     };
 

--- a/include/spsl/storage_password.hpp
+++ b/include/spsl/storage_password.hpp
@@ -77,6 +77,10 @@ public:
     size_type size() const { return _l.m_length; }
     bool empty() const { return _l.m_length == 0; }
 
+    // access to the underlying allocator
+    allocator& getAllocator() noexcept { return *this; }
+    const allocator& getAllocator() const noexcept { return *this; }
+
     // note: This function is *not* constexpr to stay compatible with C++11
     static const size_type _roundRequiredCapacityToBlockSize(size_type cap)
     {
@@ -138,19 +142,19 @@ public:
     }
 
     // default constructor
-    StoragePassword() noexcept : m_buffer(_b)
+    StoragePassword(const allocator& alloc = allocator()) noexcept : allocator(alloc), m_buffer(_b)
     {
         _l.m_capacity = 0;
         _set_length(0);
     }
 
     // implement copy & move
-    StoragePassword(const this_type& other) : StoragePassword()
+    StoragePassword(const this_type& other) : StoragePassword(other.getAllocator())
     {
         if (!other.empty())
             assign(other.data(), other.size());
     }
-    StoragePassword(this_type&& other) noexcept : StoragePassword()
+    StoragePassword(this_type&& other) noexcept : StoragePassword(other.getAllocator())
     {
         swap(other);
         other.clear();
@@ -412,6 +416,7 @@ public:
             other.m_buffer = other._b;
         if (m_buffer == other._b)
             m_buffer = _b;
+        std::swap(getAllocator(), other.getAllocator());
     }
 
 protected:
@@ -439,7 +444,7 @@ protected:
     /// the underlying buffer
     char_type* m_buffer;
 };
-}
+} // namespace spsl
 
 
 #endif /* SPSL_STORAGE_PASSWORD_HPP_ */

--- a/include/spsl/stringbase.hpp
+++ b/include/spsl/stringbase.hpp
@@ -295,8 +295,8 @@ public:
     template <class InputIt, typename = checkInputIter<InputIt>>
     this_type& replace(const_iterator first, const_iterator last, InputIt first2, InputIt last2)
     {
-        size_type pos = first - data();
-        size_type count = last - first;
+        size_type pos = static_cast<size_type>(first - data());
+        size_type count = static_cast<size_type>(last - first);
         if (pos > size())
             throw std::out_of_range("replace: pos > size()");
         if (pos + count > size())
@@ -310,7 +310,8 @@ public:
     this_type& replace(const_iterator first, const_iterator last, const char_type* cstr,
                        size_type count2)
     {
-        return replace(first - data(), last - first, cstr, count2);
+        return replace(static_cast<size_type>(first - data()), static_cast<size_type>(last - first),
+                       cstr, count2);
     }
     this_type& replace(size_type pos, size_type count, const char_type* cstr)
     {
@@ -318,16 +319,19 @@ public:
     }
     this_type& replace(const_iterator first, const_iterator last, const char_type* cstr)
     {
-        return replace(first - data(), last - first, cstr, traits_type::length(cstr));
+        return replace(static_cast<size_type>(first - data()), static_cast<size_type>(last - first),
+                       cstr, traits_type::length(cstr));
     }
     this_type& replace(const_iterator first, const_iterator last, size_type count2, char_type ch)
     {
-        return replace(first - data(), last - first, count2, ch);
+        return replace(static_cast<size_type>(first - data()), static_cast<size_type>(last - first),
+                       count2, ch);
     }
     this_type& replace(const_iterator first, const_iterator last,
                        std::initializer_list<char_type> ilist)
     {
-        return replace(first - data(), last - first, ilist.begin(), ilist.size());
+        return replace(static_cast<size_type>(first - data()), static_cast<size_type>(last - first),
+                       ilist.begin(), ilist.size());
     }
 
     template <typename StringClass, typename std::enable_if<is_compatible_string<
@@ -341,7 +345,8 @@ public:
                                       char_type, size_type, StringClass>::value>::type* = nullptr>
     this_type& replace(const_iterator first, const_iterator last, const StringClass& s)
     {
-        return replace(first - data(), last - first, s.data(), s.size());
+        return replace(static_cast<size_type>(first - data()), static_cast<size_type>(last - first),
+                       s.data(), s.size());
     }
 
     template <typename StringClass, typename std::enable_if<is_compatible_string<
@@ -442,7 +447,7 @@ public:
                 for (size_type ind2 = 0; ind2 < count; ++ind2)
                 {
                     if (traits_type::eq(*ptr, s[ind2]))
-                        return (ptr - d);
+                        return static_cast<size_type>(ptr - d);
                 }
             }
         }
@@ -483,7 +488,7 @@ public:
                         found = true;
                 }
                 if (!found)
-                    return (ptr - d);
+                    return static_cast<size_type>(ptr - d);
             }
         }
         return npos;
@@ -499,7 +504,7 @@ public:
             for (const char_type* ptr = d + pos; ptr >= d; --ptr)
             {
                 if (!traits_type::eq(*ptr, ch))
-                    return (ptr - d);
+                    return static_cast<size_type>(ptr - d);
             }
         }
         return npos;
@@ -527,7 +532,7 @@ template <typename CharType, typename CharTraits, typename StorageType,
 inline std::basic_ostream<CharType, CharTraits>& operator<<(
   std::basic_ostream<CharType, CharTraits>& os, const StringBase<StorageType>& str)
 {
-    os.write(str.data(), str.size());
+    os.write(str.data(), static_cast<std::streamsize>(str.size()));
     return os;
 }
 

--- a/include/spsl/stringcore.hpp
+++ b/include/spsl/stringcore.hpp
@@ -337,7 +337,7 @@ public:
         if (r == 0)
         {
             // compare the length difference if the strings are equal (so far)
-            difference_type diff = this_len - other_len;
+            difference_type diff = static_cast<difference_type>(this_len - other_len);
             if (diff > std::numeric_limits<int>::max())
                 diff = std::numeric_limits<int>::max();
             else if (diff < std::numeric_limits<int>::min())
@@ -478,7 +478,7 @@ public:
             const size_type n = mysize - pos;
             const char_type* p = traits_type::find(mydata + pos, n, ch);
             if (p)
-                ret = p - mydata;
+                ret = static_cast<size_type>(p - mydata);
         }
         return ret;
     }
@@ -507,7 +507,7 @@ public:
             for (const char_type* ptr = d + pos; ptr >= d; --ptr)
             {
                 if (traits_type::compare(ptr, s, count) == 0)
-                    return (ptr - d);
+                    return static_cast<size_type>(ptr - d);
             }
         }
         return npos;
@@ -523,7 +523,7 @@ public:
             for (const char_type* ptr = d + pos; ptr >= d; --ptr)
             {
                 if (traits_type::eq(*ptr, ch))
-                    return (ptr - d);
+                    return static_cast<size_type>(ptr - d);
             }
         }
         return npos;

--- a/test/test_pagealloc.cpp
+++ b/test/test_pagealloc.cpp
@@ -277,7 +277,8 @@ TEST(PageAllocTest, LeakCheckTest2)
         {
             // note: we iterate backwards to have stable indexes, but collect "in order"
             myLeaks.insert(myLeaks.begin(), allocations[index]);
-            allocations.erase(allocations.begin() + index);
+            allocations.erase(allocations.begin() +
+                              static_cast<AllocationList::difference_type>(index));
         }
 
         for (auto& entry : allocations)

--- a/test/test_storagepassword.cpp
+++ b/test/test_storagepassword.cpp
@@ -602,21 +602,24 @@ TYPED_TEST(StoragePasswordTest, CopyAndMoveTests)
     ASSERT_EQ(string1.getAllocator().pageAllocator(), &alloc1);
     ASSERT_EQ(string2.getAllocator().pageAllocator(), &alloc2);
 
-    // copying the string copies the allocator
-    StorageType string3 = string1;
+    // using the copy or move constructor copies the allocator
+    StorageType string3(string1);
+    StorageType string4(std::move(string1));
     ASSERT_EQ(string1.getAllocator().pageAllocator(), &alloc1);
     ASSERT_EQ(string3.getAllocator().pageAllocator(), &alloc1);
+    ASSERT_EQ(string4.getAllocator().pageAllocator(), &alloc1);
+    // copy assignment doesn't
     string3 = string2;
-    ASSERT_EQ(string3.getAllocator().pageAllocator(), &alloc2);
+    ASSERT_EQ(string3.getAllocator().pageAllocator(), &alloc1);
 
     // moving swaps the allocator
     auto defaultAlloc = &spsl::SensitivePageAllocator::getDefaultInstance();
-    StorageType string4;
-    ASSERT_EQ(string4.getAllocator().pageAllocator(), defaultAlloc);
-    string4 = std::move(string1);
-    ASSERT_EQ(string4.getAllocator().pageAllocator(), &alloc1);
+    StorageType string5;
+    ASSERT_EQ(string5.getAllocator().pageAllocator(), defaultAlloc);
+    string5 = std::move(string1);
+    ASSERT_EQ(string5.getAllocator().pageAllocator(), &alloc1);
     ASSERT_EQ(string1.getAllocator().pageAllocator(), defaultAlloc);
-    string4.swap(string1);
+    string5.swap(string1);
     ASSERT_EQ(string1.getAllocator().pageAllocator(), &alloc1);
-    ASSERT_EQ(string4.getAllocator().pageAllocator(), defaultAlloc);
+    ASSERT_EQ(string5.getAllocator().pageAllocator(), defaultAlloc);
 }

--- a/test/test_storagepassword.cpp
+++ b/test/test_storagepassword.cpp
@@ -31,7 +31,7 @@ struct WipeCheckAllocator
     {
         for (size_t i = 0; i < size; ++i)
         {
-            ASSERT_EQ(ptr[i], (T)0);
+            ASSERT_EQ(ptr[i], static_cast<T>(0));
         }
         free(ptr);
     }
@@ -59,7 +59,7 @@ TYPED_TEST(StoragePasswordTest, ConstructorTests)
 
     const StorageType s1;
     ASSERT_EQ(s1.capacity(), 0);
-    ASSERT_EQ(s1.max_size(), ((size_t)-1) / sizeof(CharType));
+    ASSERT_EQ(s1.max_size(), static_cast<size_t>(-1) / sizeof(CharType));
 
     ASSERT_TRUE(s1.empty());
     ASSERT_EQ(s1.length(), 0);
@@ -575,9 +575,9 @@ TYPED_TEST(StoragePasswordTest, CopyAndMoveTests)
     // create 2 distinct page allocator instances
     spsl::SensitivePageAllocator alloc1, alloc2;
     // use them in 2 different strings
-    StorageType string1{spsl::SensitiveSegmentAllocator<CharType>(alloc1)};
+    StorageType string1{ spsl::SensitiveSegmentAllocator<CharType>(alloc1) };
     string1.assign(data.hello_world, data.hello_world_len);
-    StorageType string2{spsl::SensitiveSegmentAllocator<CharType>(alloc2)};
+    StorageType string2{ spsl::SensitiveSegmentAllocator<CharType>(alloc2) };
     string2.assign(data.hello_world, data.hello_world_len);
 
     // same content, different allocators

--- a/test/test_stringbase.cpp
+++ b/test/test_stringbase.cpp
@@ -110,7 +110,7 @@ TYPED_TEST(StringBaseTest, FindFirstOfFunctions)
     ASSERT_EQ(s.find_first_of(chars4, 0), npos);
     ASSERT_EQ(sWithNul.find_first_of(chars4), sWithNul.size() - 1);
     ASSERT_EQ(sWithNul.find_first_of(chars4, 0), sWithNul.size() - 1);
-};
+}
 
 
 /* find_first_not_of functions */

--- a/test/test_stringcore.cpp
+++ b/test/test_stringcore.cpp
@@ -722,12 +722,8 @@ TYPED_TEST(StringCoreTest, Operations)
     ASSERT_THROW(s1.substr(s1.size() + 1), std::out_of_range);
     ASSERT_THROW(s2.substr(s2.size() + 1), std::out_of_range);
 
-// copy
-#ifdef SPSL_HAS_CONSTEXPR_ARRAY
-    CharType buffer[data.hello_world_len + 1];
-#else
+    // copy
     CharType buffer[256];
-#endif
     for (size_t pos = 0; pos <= data.hello_world_len; ++pos)
     {
         // + 10 because we are allowed to ask for more

--- a/test/test_stringcore.cpp
+++ b/test/test_stringcore.cpp
@@ -757,7 +757,7 @@ TYPED_TEST(StringCoreTest, Operations)
     ASSERT_TRUE(s1 == data.hello_world);
     ASSERT_EQ(s1.size(), data.hello_world_len);
     // shrink tests
-    for (size_t i = data.hello_world_len; i != (size_t)-1; --i)
+    for (size_t i = data.hello_world_len; i != static_cast<size_t>(-1); --i)
     {
         s1.resize(i);
         ASSERT_EQ(s1.size(), i);
@@ -913,7 +913,7 @@ TYPED_TEST(StringCoreTest, ComparisonFunctions)
     ASSERT_EQ(s.compare(ref.c_str()), 0);
     ref[0]++;
     ASSERT_LT(s.compare(ref.c_str()), 0);
-    ref[0] -= 2;
+    ref[0] = static_cast<CharType>(ref[0] - 2);
     ASSERT_GT(s.compare(ref.c_str()), 0);
     ref = s.c_str();
     ref.pop_back();
@@ -954,7 +954,7 @@ TYPED_TEST(StringCoreTest, ComparisonFunctions)
     ASSERT_EQ(s.compare(ref), 0);
     ref[0]++;
     ASSERT_LT(s.compare(ref), 0);
-    ref[0] -= 2;
+    ref[0] = static_cast<CharType>(ref[0] - 2);
     ASSERT_GT(s.compare(ref), 0);
     ref = s;
     ref.pop_back();
@@ -1100,7 +1100,7 @@ TYPED_TEST(StringCoreTest, ComparisonOperators)
     ASSERT_TRUE(s >= ref.c_str());
     ASSERT_FALSE(s < ref.c_str());
     ASSERT_FALSE(s <= ref.c_str());
-    ref[0] += 2;
+    ref[0] = static_cast<CharType>(ref[0] + 2);
     ASSERT_TRUE(s < ref.c_str());
     ASSERT_TRUE(s <= ref.c_str());
     ASSERT_FALSE(s > ref.c_str());
@@ -1120,7 +1120,7 @@ TYPED_TEST(StringCoreTest, ComparisonOperators)
     ASSERT_TRUE(ref.c_str() <= s);
     ASSERT_FALSE(ref.c_str() > s);
     ASSERT_FALSE(ref.c_str() >= s);
-    ref[0] += 2;
+    ref[0] = static_cast<CharType>(ref[0] + 2);
     ASSERT_TRUE(ref.c_str() > s);
     ASSERT_TRUE(ref.c_str() >= s);
     ASSERT_FALSE(ref.c_str() < s);
@@ -1143,7 +1143,7 @@ TYPED_TEST(StringCoreTest, ComparisonOperators)
     ASSERT_TRUE(s >= ref2);
     ASSERT_FALSE(s < ref2);
     ASSERT_FALSE(s <= ref2);
-    ref2[0] += 2;
+    ref2[0] = static_cast<CharType>(ref2[0] + 2);
     ASSERT_TRUE(s < ref2);
     ASSERT_TRUE(s <= ref2);
     ASSERT_FALSE(s > ref2);
@@ -1168,7 +1168,7 @@ TYPED_TEST(StringCoreTest, ComparisonOperators)
     ASSERT_TRUE(s >= ref);
     ASSERT_FALSE(s < ref);
     ASSERT_FALSE(s <= ref);
-    ref[0] += 2;
+    ref[0] = static_cast<CharType>(ref[0] + 2);
     ASSERT_TRUE(s < ref);
     ASSERT_TRUE(s <= ref);
     ASSERT_FALSE(s > ref);
@@ -1193,7 +1193,7 @@ TYPED_TEST(StringCoreTest, ComparisonOperators)
     ASSERT_TRUE(ref <= s);
     ASSERT_FALSE(ref > s);
     ASSERT_FALSE(ref >= s);
-    ref[0] += 2;
+    ref[0] = static_cast<CharType>(ref[0] + 2);
     ASSERT_TRUE(ref > s);
     ASSERT_TRUE(ref >= s);
     ASSERT_FALSE(ref < s);


### PR DESCRIPTION
Copy/move semantics were broken and the SensitivePageAllocator may warn about leaks (because memory was returned to the wrong instance).